### PR TITLE
croak import

### DIFF
--- a/lib/Dist/Zilla/Plugin/InsertCopyright.pm
+++ b/lib/Dist/Zilla/Plugin/InsertCopyright.pm
@@ -8,6 +8,7 @@ package Dist::Zilla::Plugin::InsertCopyright;
 
 use PPI::Document;
 use Moose;
+use Carp qw/croak/;
 
 with 'Dist::Zilla::Role::FileMunger';
 


### PR DESCRIPTION
This module does not know about croak, so if it tries to croak something like this will happen:

`Undefined subroutine &Dist::Zilla::Plugin::InsertCopyright::croak called at /usr/local/share/perl/5.14.2/Dist/Zilla/Plugin/InsertCopyright.pm line 51.`

Please note that I failed to do a dzil test, dist.ini seems outdated - our of scope for this pull request.
